### PR TITLE
Add in_channel twine decoder

### DIFF
--- a/src/leb128/imandrakit_leb128.ml
+++ b/src/leb128/imandrakit_leb128.ml
@@ -32,7 +32,7 @@ module Decode = struct
     let res = ref 0L in
     let continue = ref true in
 
-    let off = ref off in
+    let off = ref (sl.off + off) in
     let n_consumed = ref 0 in
 
     while !continue do

--- a/src/twine/decode.ml
+++ b/src/twine/decode.ml
@@ -36,7 +36,7 @@ let read_char t offset =
   let (Decode { st; ops; _ }) = t in
   ops.read_char st offset
 
-let read_int32 (type a) t offset =
+let read_int32 t offset =
   let (Decode { st; ops; _ }) = t in
   ops.read_int32 st offset
 

--- a/src/twine/decode.ml
+++ b/src/twine/decode.ml
@@ -247,8 +247,6 @@ let[@inline] deref_rec self off : offset =
   else
     off
 
-exception Foo of string
-
 let read ?(auto_deref = true) (self : t) (offset : offset) : Value.t =
   let offset =
     if auto_deref then

--- a/src/twine/decode.ml
+++ b/src/twine/decode.ml
@@ -79,13 +79,13 @@ let in_channel_ops : in_channel ops =
       (fun (st : in_channel) (offset : int) ->
         let bs = Bytes.create 4 in
         In_channel.seek st (Int64.of_int offset);
-        let _ = In_channel.input st bs 0 4 in
+        let _ = In_channel.really_input st bs 0 4 in
         Bytes.get_int32_le bs 0);
     read_int64 =
       (fun (st : in_channel) (offset : int) ->
         let bs = Bytes.create 8 in
         In_channel.seek st (Int64.of_int offset);
-        let _ = In_channel.input st bs 0 8 in
+        let _ = In_channel.really_input st bs 0 8 in
         Bytes.get_int64_le bs 0);
     read_blob =
       (fun (st : in_channel) (offset : int) (length : int) ->
@@ -93,7 +93,7 @@ let in_channel_ops : in_channel ops =
         let length = min length remaining in
         let bs = Bytes.create length in
         In_channel.seek st (Int64.of_int offset);
-        let _ = In_channel.input st bs 0 length in
+        let _ = In_channel.really_input st bs 0 length in
         Slice.create bs);
     read_leb128 =
       (fun (st : in_channel) (offset : int) ->
@@ -101,7 +101,7 @@ let in_channel_ops : in_channel ops =
         let length = min 16 remaining in
         let bs = Bytes.create length in
         In_channel.seek st (Int64.of_int offset);
-        let _ = In_channel.input st bs 0 length in
+        let _ = In_channel.really_input st bs 0 length in
         LEB128.u64 (Slice.create bs) 0);
   }
 

--- a/src/twine/decode.mli
+++ b/src/twine/decode.mli
@@ -2,8 +2,9 @@ open Types
 
 type t
 
-val create : slice -> t
+val of_slice : slice -> t
 val of_string : string -> t
+val of_in_channel : in_channel -> t
 val hmap_set : t -> 'a Hmap.key -> 'a -> unit
 val hmap_get : t -> 'a Hmap.key -> 'a option
 
@@ -74,12 +75,12 @@ module Dict_cursor : sig
 end
 
 val deref_rec : offset decoder
-(** Given any value, follow pointers until a non-pointer value is reached,
-    a return its address. *)
+(** Given any value, follow pointers until a non-pointer value is reached, a
+    return its address. *)
 
 val read : ?auto_deref:bool -> Value.t decoder
 (** Read a value of any kind.
- @param auto_deref if true (default), follow pointers implicitly *)
+    @param auto_deref if true (default), follow pointers implicitly *)
 
 val null : unit decoder
 val bool : bool decoder
@@ -116,13 +117,11 @@ val decode_string : ?init:(t -> unit) -> 'a decoder -> string -> 'a
 
 (** {2 Caching}
 
-  Caching is used to reflect the sharing of values
-  embedded in a Twine slice, into the decoded values.
-  It means that, for a given type, if values of this type
-  are encoded with sharing (e.g. a graph-heavy term representation),
-  then with caching we can decode the values to OCaml values
-  that also have sharing.
-*)
+    Caching is used to reflect the sharing of values embedded in a Twine slice,
+    into the decoded values. It means that, for a given type, if values of this
+    type are encoded with sharing (e.g. a graph-heavy term representation), then
+    with caching we can decode the values to OCaml values that also have
+    sharing. *)
 
 type 'a cache_key
 (** Generative key used to cache values during decoding *)
@@ -130,25 +129,23 @@ type 'a cache_key
 val create_cache_key : unit -> _ cache_key
 (** Generate a new (generative) cache key for a type.
 
-    {b NOTE} this should be called only at module toplevel, as a constant,
-    not dynamically inside a function:
-    [let key: foo value_pack.Deser.cache_key = value_pack.Deser.create_cache_key ();;].
-    Indeed, this is generative, so creating multiple keys for a type
+    {b NOTE} this should be called only at module toplevel, as a constant, not
+    dynamically inside a function:
+    [let key: foo value_pack.Deser.cache_key = value_pack.Deser.create_cache_key
+     ();;]. Indeed, this is generative, so creating multiple keys for a type
     will result in sub-par performance or non-existent caching. *)
 
 val with_cache : 'a cache_key -> 'a decoder -> 'a decoder
-(** [with_cache key dec] is the same decoder as [dec] but
-      it uses [key] to retrieve values directly from
-      an internal table for entries/values that have already
-      been decoded in the past. This means that a value that was
-      encoded with a lot of sharing (e.g in a graph, or a large
-      string using {!Ser.add_string}) will be decoded only once.
-  *)
+(** [with_cache key dec] is the same decoder as [dec] but it uses [key] to
+    retrieve values directly from an internal table for entries/values that have
+    already been decoded in the past. This means that a value that was encoded
+    with a lot of sharing (e.g in a graph, or a large string using
+    {!Ser.add_string}) will be decoded only once. *)
 
 val add_cache : 'a decoder ref -> unit
-(** [add_cache dec_ref] modifies the decoder so it uses a new cache key.
-    It is the same as:
-  {[
-  let key = create_cache_key ()
-  let () = dec_ref := with_cache key !dec_ref
-  ]} *)
+(** [add_cache dec_ref] modifies the decoder so it uses a new cache key. It is
+    the same as:
+    {[
+      let key = create_cache_key ()
+      let () = dec_ref := with_cache key !dec_ref
+    ]} *)

--- a/src/twine/dump.ml
+++ b/src/twine/dump.ml
@@ -149,7 +149,7 @@ let default_string_ellipsis_threshold = 30
 
 let dump_slice ?(string_ellipsis_threshold = default_string_ellipsis_threshold)
     (sl : slice) : string =
-  let dec = Decode.create sl in
+  let dec = Decode.of_slice sl in
   let st = { offset = Int_map.empty; dec; string_ellipsis_threshold } in
   dump_rec st (Decode.get_entrypoint dec);
   let buf = Buffer.create 32 in

--- a/test/twine/dune
+++ b/test/twine/dune
@@ -1,5 +1,5 @@
 (tests
- (names t1 t2 t3 t4 t5 t6 t7 t8 t9 t10 t11 t12)
+ (names t1 t2 t3 t4 t5 t6 t7 t8 t9 t10 t11 t12 t_file_1)
  (libraries imandrakit.twine hex ppx_deriving.runtime unix)
  (package imandrakit)
  (preprocess

--- a/test/twine/t_file_1.expected
+++ b/test/twine/t_file_1.expected
@@ -1,0 +1,7 @@
+t_out: { T_file_1.a = 43; b = (Types.Offset_for 13);
+         c = (Types.Offset_for 13) }
+t_in : { T_file_1.a = 43; b = (Types.Offset_for 13);
+         c = (Types.Offset_for 13) }
+a=43 b=XYZ c=XYZ
+00000000: 4c55 4e55 5345 4420 5354 5546 4643 5859  LUNUSED STUFFCXY
+00000001: 5a63 1f1c e6e7 04                        Zc.....

--- a/test/twine/t_file_1.ml
+++ b/test/twine/t_file_1.ml
@@ -12,7 +12,7 @@ class twine_out_channel (oc : out_channel) =
     method output bs i len = output oc bs i len
   end
 
-let _ =
+let () =
   let tfn = Filename.temp_file "imandrakit." ".test" in
   Fun.protect ~finally:(fun _ -> Sys.remove tfn) @@ fun () ->
   (* Start a twine file with some immediate values *)

--- a/test/twine/t_file_1.ml
+++ b/test/twine/t_file_1.ml
@@ -1,0 +1,56 @@
+open Imandrakit_twine
+
+type t = {
+  a: int;
+  b: string Imandrakit_twine.offset_for;
+  c: string Imandrakit_twine.offset_for;
+}
+[@@deriving twine, show]
+
+class twine_out_channel (oc : out_channel) =
+  object
+    method output bs i len = output oc bs i len
+  end
+
+let _ =
+  let tfn = Filename.temp_file "imandrakit." ".test" in
+  Fun.protect ~finally:(fun _ -> Sys.remove tfn) @@ fun () ->
+  (* Start a twine file with some immediate values *)
+  let oc = open_out_bin tfn in
+  let enc = Encode.create () in
+  let out : Encode.out = new twine_out_channel oc in
+  let _ = Encode.write_immediate enc (Immediate.string "UNUSED STUFF") in
+  let off_xyz = Encode.write_immediate enc (Immediate.string "XYZ") in
+
+  (* Write a twine blob containing references *)
+  let t_out = { a = 43; b = Offset_for off_xyz; c = Offset_for off_xyz } in
+  Format.printf "t_out: %a@." pp t_out;
+
+  let entrypoint = to_twine enc t_out in
+  let _ = Encode.finalize enc ~entrypoint in
+  Imandrakit_twine.Encode.write_internal_data enc out;
+  flush oc;
+  close_out oc;
+
+  (* Now read the back from twine file *)
+  let ic = open_in_bin tfn in
+  let dec = Decode.of_in_channel ic in
+  let t_in = of_twine dec (Decode.get_entrypoint dec) in
+
+  Format.printf "t_in : %a@." pp t_in;
+
+  (* Make sure we can dereference correctly *)
+  let b = Decode.read_ref dec Decode.string t_in.b in
+  let c = Decode.read_ref dec Decode.string t_in.c in
+  close_in ic;
+
+  Format.printf "a=%d b=%s c=%s@." t_in.a b c;
+  assert (String.equal b c && String.equal b "XYZ");
+  assert (t_out = t_in);
+
+  (* Dump the file so we get a test failure if the contents change *)
+  let ic = open_in_bin tfn in
+  let n = Int64.to_int (In_channel.length ic) in
+  let bs = Bytes.create n in
+  really_input ic bs 0 n;
+  Hex.hexdump (Hex.of_bytes bs)


### PR DESCRIPTION
I used ocamlformat 0.27.0 because that's what we use in imandrax. Should we upgrade imandrakit to use the same version?